### PR TITLE
Fix footer text and typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+build/
+build.zip

--- a/src/components/Footer/index.jsx
+++ b/src/components/Footer/index.jsx
@@ -1,7 +1,6 @@
 import styles from "./Footer.module.scss";
 import logo from '../../images/svg/logo.svg'
 import policy from '../../files/policy.pdf';
-import offerta from '../../files/offerta.pdf'
 import Button from "../Button";
 import { goToLink } from "../../helpers/helpers";
 
@@ -18,7 +17,7 @@ const Footer = () => {
         Связь с менеджером
       </Button>
       <div className={styles.footerPhone}>
-        с 10:00 - 22:00 пн-пт
+        С 11:00 - 21:00 ЕЖЕДНЕВНО
       </div>
       </div>
       <div className={styles.footerColumn}>
@@ -29,7 +28,6 @@ const Footer = () => {
           г. Москва
         </p>
         <a className={styles.footerDocument} download href={policy}>Политика конфиденциальности</a>
-        <a className={styles.footerDocument} download href={offerta}>Договор оферта</a>
       </div>
     </div>
   );

--- a/src/components/Services/index.jsx
+++ b/src/components/Services/index.jsx
@@ -10,7 +10,7 @@ const Services = () => {
   const services = [
     {
       img: <ServiceIMG1 />,
-      title: "ИНДИВИДУАЛЬАЯ СБОРКА",
+      title: "ИНДИВИДУАЛЬНАЯ СБОРКА",
       text: (
         <div className={styles.serviceDescription}>
           <div className={styles.serviceDescriptionLine}>Высокая мощность или компактность?</div>

--- a/src/components/TelegramProduct/ProductFooter/index.jsx
+++ b/src/components/TelegramProduct/ProductFooter/index.jsx
@@ -27,7 +27,7 @@ export const ProductFooter = () => {
       <div className={styles.footerDelivery}>
         <div className={styles.footerDeliveryHeader}>
           <div className={styles.footerDeliveryHeaderText}>
-            Доставляем по всем регионам РФи странам ЕАЭС
+            Доставляем по всем регионам РФ и странам ЕАЭС
           </div>
           <DeliverySVG className={styles.footerDeliveryHeaderIcon} />
         </div>


### PR DESCRIPTION
## Summary
- correct typo in service title
- update footer schedule and remove offer link
- fix delivery header text
- add build and artifacts to `.gitignore`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6858dff063e08323aaa4625aa34872c2